### PR TITLE
Install a `salt-shaker` binary form the setup.py

### DIFF
--- a/scripts/salt-shaker
+++ b/scripts/salt-shaker
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import sys
+from shaker.shaker import ShakerCommandLine
+
+ShakerCommandLine().run(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from distutils.core import setup
 
 setup(
-    name='shaker',
+    name='salt-shaker',
     version='0.0.1',
     package_dir={'': 'src'},
     packages=['shaker'],
-    url='',
+    url='http://github.com/ministryofjustice/salt_shaker',
     license='',
     author='MoJ DS Infrastucture Team',
     author_email='webops@digital.justice.gov.uk',
@@ -13,7 +13,7 @@ setup(
     install_requires=[
         'requests',
         'PyYAML',
-        'pygit2'
+        'pygit2',
     ],
-    dependency_links=[]
+    scripts=['scripts/salt-shaker'],
 )

--- a/src/shaker/shaker.py
+++ b/src/shaker/shaker.py
@@ -42,8 +42,12 @@ class ShakerCommandLine(cmd.Cmd):
         print msg
 
 
+    def run(self, argv):
+        if len(argv) > 1:
+            self.onecmd(' '.join(argv[1:]))
+        else:
+            self.do_help('')
+
+
 if __name__ == '__main__':
-    if len(sys.argv) > 1:
-        ShakerCommandLine().onecmd(' '.join(sys.argv[1:]))
-    else:
-        ShakerCommandLine().do_help('')
+    ShakerCommandLine().run(sys.argv)


### PR DESCRIPTION
We still need 'master' verion of pygit2. This will give us both of what we want

`pip install git+http://github.com/libgit/pygit2.git git+http://github.com/ministryofjustice/salt-shaker.git`

and `brew intall libgit2 --with-libssh2` on OSX will get a 'useful' libgit2 with ssh support
