### PR TITLE
Fixes empty formula dependencies edge case

### DIFF
--- a/shaker/resolve_deps.py
+++ b/shaker/resolve_deps.py
@@ -141,10 +141,11 @@ def get_reqs(org_name, formula_name, constraint=None):
         reqs = filter(lambda x: len(x) > 0, reqs.text.split('\n'))
 
     out = []
-    for req in reqs:
-        org, formula = req.split(':')[1].split('.git')[0].split('/')
-        constraint = req.split('.git')[1] if found_metadata else ''
-        out.append(map(str, (org, formula, constraint)))
+    if reqs:
+        for req in reqs:
+            org, formula = req.split(':')[1].split('.git')[0].split('/')
+            constraint = req.split('.git')[1] if found_metadata else ''
+            out.append(map(str, (org, formula, constraint)))
 
     res = {'tag': wanted_tag, 'deps': out}
     if data:

--- a/tests/test_resolve_deps.py
+++ b/tests/test_resolve_deps.py
@@ -237,3 +237,32 @@ class ResolveDepsTest(unittest.TestCase):
         deps = resolve_deps.get_reqs_recursive([['ministryofjustice', 'toplevel-formula', '']])
 
         self.assertEqual(all_formulas, deps)
+
+    @patch.object(resolve_deps, 'get_reqs')
+    def test_get_reqs_empty_deps(self, mock_get_reqs):
+        all_formulas = {
+            'ministryofjustice/simple-formula': {
+                'tag' : None,
+                'deps': [],
+                'metadata': {
+                    'entry': None, 
+                    'dependencies': None
+                 }
+            }
+        }
+
+        def get_reqs_return_value(org, formula, constraint):
+            return all_formulas["{}/{}".format(org, formula)]
+
+        mock_get_reqs.side_effect = get_reqs_return_value
+
+        deps = resolve_deps.get_reqs('ministryofjustice', 'simple-formula', '')
+
+        self.assertEqual({
+            'tag' : None,
+            'deps': [],
+            'metadata': {
+                'entry': None, 
+                'dependencies': None
+             }
+        }, deps)


### PR DESCRIPTION
When a formula has no dependencies but specifies ```metadata.yml```, ```salt-shaker``` crashes. This PR handles this edge case but it's probably not idiomatic Python.

Fixes #17  