### PR TITLE
Issue #15: Improve error handling around github tokens

### DIFF
--- a/shaker/helpers.py
+++ b/shaker/helpers.py
@@ -1,0 +1,99 @@
+import logging
+import json
+import requests
+import os
+
+def get_valid_github_token(online_validation_enabled = False):
+    """
+    Check for a github token environment variable. If its not there,
+    or is invalid, log a message and return None. Otherwise, return the token string
+
+    Parameters:
+        online_validation_enabled (bool): If True, then try out the credentials against
+        the github api for success. No online validation if false
+    Returns:
+        github_token (string): The valid github token, None if invalid
+    """
+    github_token = None
+    
+    # A simple check for the right environment variable
+    if not "GITHUB_TOKEN" in os.environ:
+        msg = "No github token found. Please set your GITHUB_TOKEN environment variable"
+        logging.error(msg)
+    else:
+        # Test an oauth call to the api, make sure the credentials are
+        # valid and we're not locked out
+        if online_validation_enabled:
+            url = "https://api.github.com"
+            response = requests.get(url,
+                             auth=(os.environ["GITHUB_TOKEN"], 'x-oauth-basic'))
+
+            # Validate the response against expected status codes
+            # Set the return value to the token if we have success
+            valid_response = validate_github_access(response)
+            if valid_response:
+                github_token = os.environ["GITHUB_TOKEN"]
+        else:
+            # If we're not validating online, just accept that we have a token
+            github_token = os.environ["GITHUB_TOKEN"]
+
+    return github_token
+
+def validate_github_access(response):
+    """
+    Validate the github api's response for known credential problems
+    
+    Checked responses are
+    
+        * Authenticating with invalid credentials will return 401 Unauthorized:
+    
+        HTTP/1.1 401 Unauthorized 
+        { 
+            "message": "Bad credentials", 
+            "documentation_url": "https://developer.github.com/v3"
+        }
+        
+        * Forbidden
+        HTTP/1.1 403 Forbidden
+        {
+          "message": "Maximum number of login attempts exceeded. Please try again later.",
+          "documentation_url": "https://developer.github.com/v3"
+        }
+
+    Args:
+        response (requests.models.Response): The Response from the github server
+        
+    Returns:
+        valid_credentials (bool): True if access was successful, false otherwise
+
+    """
+    
+    # Assume invalid credentials unless proved otherwise
+    valid_credentials = False
+    
+    if (type(response) == requests.models.Response):
+        
+        # Check the status codes for success
+        if response.status_code == 200:
+            logging.info("Github access checked ok")
+            valid_credentials = True
+        else:
+             # Set a default response message, use the real one if we
+             # find it in the response 
+            response_message = "No response found"
+            try:
+                # Access the responses body as json
+                response_json = json.loads(response.text)
+                if "message" in response_json: 
+                    response_message = response_json["message"]
+            except:
+                # Just ignore if we can'l load json, its not essential here
+                pass
+                if (response.status_code == 401) and ("Bad credentials" in response_message):
+                    logging.error("Github credentials incorrect: %s" % response_message)
+                elif response.status_code == 403 and ("Maximum number of login attempts exceeded" in response_message):
+                    logging.error("Github credentials failed due to lockout: %s" % response_message)
+                else:
+                    logging.error("Unknown problem checking credentials: %s" % response_message)
+    
+    return valid_credentials

--- a/shaker/resolve_deps.py
+++ b/shaker/resolve_deps.py
@@ -4,6 +4,7 @@ import sys
 import requests
 import json
 import yaml
+import helpers
 
 const_re = re.compile('([=><]+)\s*(.*)')
 tag_re = re.compile('v[0-9]+\.[0-9]+\.[0-9]+')
@@ -56,16 +57,16 @@ def get_tags(org_name, formula_name):
             return []
 
 
-    github_token = os.environ.get('GITHUB_TOKEN', None)
+    github_token = helpers.get_valid_github_token()
     if not github_token:
-        print 'GITHUB_TOKEN is not defined. Aborting'
         sys.exit(1)
 
     tags_url = 'https://api.github.com/repos/{0}/{1}/tags'
     tag_versions = []
     tags_json = requests.get(tags_url.format(org_name, formula_name),
                              auth=(github_token, 'x-oauth-basic'))
-    if tags_json.status_code == 200:
+    # Check for successful access and any credential problems
+    if helpers.validate_github_access(tags_json):
         tag_data = json.loads(tags_json.text)
         tag_versions = [x['name'][1:] for x in tag_data]
         tag_versions.sort(key=convert_tagname)
@@ -108,9 +109,8 @@ def check_constraint(org_name, formula_name, constraint):
 
 
 def get_reqs(org_name, formula_name, constraint=None):
-    github_token = os.environ.get('GITHUB_TOKEN', None)
+    github_token = helpers.get_valid_github_token()
     if not github_token:
-        print 'GITHUB_TOKEN is not defined. Aborting'
         sys.exit(1)
 
     print 'Processing {0}/{1}'.format(org_name, formula_name)
@@ -128,7 +128,8 @@ def get_reqs(org_name, formula_name, constraint=None):
                             auth=(github_token, 'x-oauth-basic'))
 
     found_metadata = False
-    if metadata.status_code == 200:
+     # Check for successful access and any credential problems
+    if helpers.validate_github_access(metadata):
         found_metadata = True
         data = yaml.load(metadata.text)
         reqs = data['dependencies'] if 'dependencies' in data and data['dependencies'] else []

--- a/shaker/salt_shaker.py
+++ b/shaker/salt_shaker.py
@@ -13,6 +13,7 @@ import pygit2
 import yaml
 
 import resolve_deps
+import helpers
 
 
 class Shaker(object):
@@ -464,8 +465,8 @@ def get_deps(root_dir, root_formula=None, constraint=None, force=False):
     deps = {}
 
     print 'No formula-requirements found. Will generate one.'
-    if 'GITHUB_TOKEN' not in os.environ:
-        print 'Env variable GITHUB_TOKEN has not been set.'
+    github_token = helpers.get_valid_github_token()
+    if not github_token:
         sys.exit(1)
 
     formulas = get_formulas(root_formula=root_formula,

--- a/tests/test_token_errors.py
+++ b/tests/test_token_errors.py
@@ -1,0 +1,148 @@
+import unittest
+import os
+import requests
+import responses
+import json
+import logging
+from shaker import helpers
+
+class TestTokenErrors(unittest.TestCase):
+        
+    @classmethod
+    def setup_class(obj):
+        logging.basicConfig(level=logging.DEBUG)
+        pass
+    
+    @classmethod
+    def teardown_class(obj):
+        pass
+    
+    @responses.activate
+    def test_get_valid_github_token(self):
+        # Test validating a github token thats missing
+        if 'GITHUB_TOKEN' in os.environ:
+            del os.environ['GITHUB_TOKEN']
+        token = helpers.get_valid_github_token()
+        self.assertEqual(token, None, "Expected no github token to be found")
+        
+         # Test calling with a valid github token. We should expect a 
+        # 200 status
+        
+        # Setup the incorrect credential mock responses
+        mock_resp = [
+            {
+                "message": "Successful login.",
+                "mock" : "True"
+            }
+        ]
+        
+        responses.add (responses.GET,
+                       "https://api.github.com",
+                       content_type="application/json",
+                       body=json.dumps(mock_resp),
+                       status = 200
+                       )
+         
+        # Setup an invalid github token
+        os.environ['GITHUB_TOKEN'] = "FAKE_VALID_TOKEN"
+        expected_token = os.environ['GITHUB_TOKEN']
+
+        # Attempt validating the invalid token
+        github_token = helpers.get_valid_github_token()
+        url = 'https://api.github.com'
+        actual_response = requests.get(url,
+                             auth=(github_token, 'x-oauth-basic'))
+
+        # Check we got the right messages and statuses
+        response_message = json.loads(actual_response.text)[0]["message"]
+        response_mock = json.loads(actual_response.text)[0]["mock"]
+        self.assertTrue(response_mock, "Not working with the mocked response")
+        self.assertEqual(actual_response.status_code, 200, "Expected 200 response, got '%s'" %actual_response.status_code)
+        self.assertEqual(github_token, expected_token, "Expected None type token, got '%s'" %github_token)
+        
+    @responses.activate
+    def test_get_valid_github_token_online(self):
+        """ 
+        Test calling the get token function with a bad token,
+        using its online validation attempts to catch the mistake
+        """
+        
+        # Test calling with an invalid github token. We should expect a "Bad Credentials" message
+        # and a 401 status
+        
+        # Setup the incorrect credential mock responses
+        mock_resp = [
+            {
+                "documentation_url": "https://developer.github.com/v3",
+                "message": "Bad credentials",
+                "mock" : "True"
+            }
+        ]
+        
+        responses.add (responses.GET,
+                       "https://api.github.com",
+                       content_type="application/json",
+                       body=json.dumps(mock_resp),
+                       status = 401
+                       )
+         
+        # Setup an invalid github token
+        os.environ['GITHUB_TOKEN'] = "INVALID_TOKEN"
+        token = os.environ['GITHUB_TOKEN']
+
+        # Attempt validating the invalid token
+        github_token = helpers.get_valid_github_token(online_validation_enabled = True)
+        url = 'https://api.github.com'
+        actual_response = requests.get(url,
+                             auth=(github_token, 'x-oauth-basic'))
+        
+        # Check we got the right messages and statuses
+        response_message = json.loads(actual_response.text)[0]["message"]
+        response_mock = json.loads(actual_response.text)[0]["mock"]
+        self.assertTrue(response_mock, "Not working with the mocked response")
+        self.assertEqual(actual_response.status_code, 401, "Expected 401 response, got '%s'" %actual_response.status_code)
+        self.assertEqual(github_token, None, "Expected None type token, got '%s'" %github_token)
+
+    @responses.activate
+    def test_validate_blocked_github_token(self):
+        """ 
+        Test calling the get token function with a bad token that has now
+        been blocked, using its online validation attempts to catch the mistake
+        """
+        
+        # Test calling with an blocked github token. We should expect a 
+        #"Maximum number of login attempts exceeded" message
+        # and a 403 status
+        
+        # Setup the incorrect credential mock responses
+        mock_resp = [
+            {
+                "message": "Maximum number of login attempts exceeded. Please try again later.",
+                "documentation_url": "https://developer.github.com/v3",
+                "mock" : "True"
+            }
+        ]
+        
+        responses.add (responses.GET,
+                       "https://api.github.com",
+                       content_type="application/json",
+                       body=json.dumps(mock_resp),
+                       status = 403
+                       )
+         
+        # Setup an invalid github token
+        os.environ['GITHUB_TOKEN'] = "INVALID_TOKEN"
+        token = os.environ['GITHUB_TOKEN']
+
+        # Attempt validating the invalid token
+        github_token = helpers.get_valid_github_token(online_validation_enabled = True)
+        url = 'https://api.github.com'
+        actual_response = requests.get(url,
+                             auth=(github_token, 'x-oauth-basic'))
+        
+        # Check we got the right messages and statuses
+        response_message = json.loads(actual_response.text)[0]["message"]
+        response_mock = json.loads(actual_response.text)[0]["mock"]
+        self.assertTrue(response_mock, "Not working with the mocked response")
+        self.assertEqual(actual_response.status_code, 403, "Expected 401 response, got '%s'" %actual_response.status_code)
+        self.assertEqual(github_token, None, "Expected None type token, got '%s'" %github_token)


### PR DESCRIPTION
Created a method to centralise handling retrieving the github token from the environment variable, with optional online validation. Made a couple of replacements throughout the code to switch over to this method for checks. 
Also added in a method to read take a Response from a github api call, and check it over for some common credential problems so that a more specific error message can be supplied  