### PR TITLE
Issue #14: Duplicates in metadata.yml

### DIFF
--- a/shaker/helpers.py
+++ b/shaker/helpers.py
@@ -2,6 +2,7 @@ import logging
 import json
 import requests
 import os
+import re
 
 def get_valid_github_token(online_validation_enabled = False):
     """
@@ -97,3 +98,59 @@ def validate_github_access(response):
                     logging.error("Unknown problem checking credentials: %s" % response_message)
     
     return valid_credentials
+
+def parse_metadata(metadata):
+    """
+    Entry function to handle the metadata parsing workflow and return a metadata 
+    object which is cleaned up
+    
+    Args:
+        metadata (dictionary): Keyed salt formula dependency information
+    
+    Returns:
+        parsed_metadata (dictionary): The original metadata parsed and cleaned up
+    """
+    # Remove duplicates
+    parsed_metadata = resolve_metadata_duplicates(metadata)
+    return parsed_metadata
+    
+def resolve_metadata_duplicates(metadata):
+    """
+    Strip duplicates out of a metadata file. If we have no additional criteria, 
+    simply take the first one. Or can resolve by latest version or preferred organisation
+    if required
+    
+    Args:
+        metadata (dictionary): Keyed salt formula dependency information
+    
+    Returns:
+        resolved_dependencies (dictionary): The original metadata stripped of duplicates
+            If the metadata could not be resolved then we return the original args version
+    """ 
+    # Only start to make alterations if we have a valid metadata format
+    # Otherwise ignore and just return the one we were passed as an argument
+    if metadata and (type(metadata) == type({})) and ("dependencies" in metadata):
+        # Count the duplicates we find
+        count_duplicates = 0
+        
+        resolved_dependency_collection = {}
+        for dependency in metadata["dependencies"]:
+            # Filter out formula name
+            org, formula = dependency.split(':')[1].split('.git')[0].split('/')
+            
+            # Simply take the first formula found, ignore subsequent
+            # formulas with the same name even from different organisations
+            # Just warn, not erroring out
+            if not formula in resolved_dependency_collection:
+                resolved_dependency_collection[formula] = dependency 
+            else:
+                # Do some sort of tag resolution
+                count_duplicates += 1
+                logging.warning("resolve_metadata_duplicates: Skipping duplicate dependency %s" %(formula))
+        
+        # Only alter the metadata if we need to
+        if count_duplicates > 0:   
+            resolved_dependencies = resolved_dependency_collection.values()
+            metadata["dependencies"] = resolved_dependencies
+    return metadata
+    

--- a/shaker/resolve_deps.py
+++ b/shaker/resolve_deps.py
@@ -131,7 +131,8 @@ def get_reqs(org_name, formula_name, constraint=None):
      # Check for successful access and any credential problems
     if helpers.validate_github_access(metadata):
         found_metadata = True
-        data = yaml.load(metadata.text)
+        # Read in the yaml metadata from body, stripping out duplicate entries
+        data = helpers.parse_metadata(yaml.load(metadata.text))
         reqs = data['dependencies'] if 'dependencies' in data and data['dependencies'] else []
     else:
         reqs = requests.get(req_url.format(org_name, formula_name,

--- a/tests/test_metadata_handling.py
+++ b/tests/test_metadata_handling.py
@@ -2,57 +2,50 @@ import unittest
 import yaml
 from shaker import helpers
 
+
 class TestMetadataHandling(unittest.TestCase):
-    
+
     # Sample metadata with duplicates
-    _sample_metadata_duplicates = \
-"""
-dependencies:
-    - git@github.com:test_organisation/test1-formula.git
-    - git@github.com:test_organisation/test1-formula.git
-    - git@github.com:test_organisation/test2-formula.git
-    - git@github.com:test_organisation/test3-formula.git
-    - git@github.com:test_organisation/test3-formula.git
-entry:
-    - dummy
-"""
-    _sample_metadata_no_duplicates = \
-"""
-dependencies:
-    - git@github.com:test_organisation/test1-formula.git
-    - git@github.com:test_organisation/test2-formula.git
-    - git@github.com:test_organisation/test3-formula.git
-entry:
-    - dummy
-"""
+    _sample_metadata_duplicates = {
+        "dependencies": [
+            "git@github.com:test_organisation/test1-formula.git",
+            "git@github.com:test_organisation/test1-formula.git",
+            "git@github.com:test_organisation/test2-formula.git",
+            "git@github.com:test_organisation/test3-formula.git",
+            "git@github.com:test_organisation/test3-formula.git"
+        ],
+        "entry": ["dummy"]
+    }
+
+    _sample_metadata_no_duplicates = {
+        "dependencies": [
+            "git@github.com:test_organisation/test1-formula.git",
+            "git@github.com:test_organisation/test2-formula.git",
+            "git@github.com:test_organisation/test3-formula.git"
+        ],
+        "entry": ["dummy"]
+    }
+
     # Sample config that yaml load will fail to parse
-    _sample_metadata_bad_yaml = \
-    """
-    dependencies--
-        - git@github.com:test_organisation/test1-formula.git
-        - git@github.com:test_organisation/test1-formula.git
-        - git@github.com:test_organisation/test2-formula.git
-        - git@github.com:test_organisation/test3-formula.git
-        - git@github.com:test_organisation/test3-formula.git
-    entry--
-        - dummy
-    """
-    @classmethod
-    def setup_class(cls):
-        pass
-    
-    @classmethod
-    def teardown_class(cls):
-        pass
-    
+    _sample_metadata_bad_yaml = {
+        "dependencies": [
+            "git@github.com:test_organisation/test1-formula.git",
+            "git@github.com:test_organisation/test1-formula.git",
+            "git@github.com:test_organisation/test2-formula.git",
+            "git@github.com:test_organisation/test3-formula.git",
+            "git@github.com:test_organisation/test3-formula.git"
+        ],
+        "entry": ["dummy"]
+    }
+
     def test_resolve_metadata_duplicates(self):
         """
         Check if we successfully remove duplicates from a sample metadata
         """
-        original_metadata = yaml.load(self._sample_metadata_duplicates)
-        expected_metadata = yaml.load(self._sample_metadata_no_duplicates)
+        original_metadata = self._sample_metadata_duplicates
+        expected_metadata = self._sample_metadata_no_duplicates
         resolved_metadata = helpers.resolve_metadata_duplicates(original_metadata)
-        
+
         expected_metadata_dependencies = expected_metadata["dependencies"]
         resolved_metadata_dependencies = resolved_metadata["dependencies"]
         expected_metadata_entries = expected_metadata["entry"]
@@ -63,18 +56,18 @@ entry:
             self.assertTrue(expected_metadata_dependency in resolved_metadata_dependencies, 
                             "test_resolve_metadata_duplicates: dependency '%s' not found in de-duplicated metadata"
                             % (expected_metadata_dependency))
-        
+
         # Test entry found
         for expected_metadata_entry in expected_metadata_entries:
             self.assertTrue(expected_metadata_entry in resolved_metadata_entries, 
                             "test_resolve_metadata_duplicates: Entry '%s' not found in de-duplicated metadata"
                             % (expected_metadata_entry))
-            
+
     def test_resolve_metadata_duplicates_bad_metadata_object(self):
         """
         Check if resolve_metadata_duplicates can handle bad yaml
         data without breaking anything
         """
-        expected = yaml.load(self._sample_metadata_bad_yaml)
-        result = helpers.resolve_metadata_duplicates(yaml.load(self._sample_metadata_bad_yaml))
+        expected = self._sample_metadata_bad_yaml
+        result = helpers.resolve_metadata_duplicates(self._sample_metadata_bad_yaml)
         self.assertEqual(result, expected, "")

--- a/tests/test_metadata_handling.py
+++ b/tests/test_metadata_handling.py
@@ -1,39 +1,27 @@
 import unittest
 import yaml
 from shaker import helpers
-
+from nose.tools import raises
 
 class TestMetadataHandling(unittest.TestCase):
 
     # Sample metadata with duplicates
     _sample_metadata_duplicates = {
         "dependencies": [
-            "git@github.com:test_organisation/test1-formula.git",
-            "git@github.com:test_organisation/test1-formula.git",
-            "git@github.com:test_organisation/test2-formula.git",
-            "git@github.com:test_organisation/test3-formula.git",
-            "git@github.com:test_organisation/test3-formula.git"
+            "git@github.com:test_organisation/test1-formula.git==v1.0.1",
+            "git@github.com:test_organisation/test1-formula.git==v1.0.2",
+            "git@github.com:test_organisation/test2-formula.git==v2.0.1",
+            "git@github.com:test_organisation/test3-formula.git==v3.0.1",
+            "git@github.com:test_organisation/test3-formula.git==v3.0.2"
         ],
         "entry": ["dummy"]
     }
 
     _sample_metadata_no_duplicates = {
         "dependencies": [
-            "git@github.com:test_organisation/test1-formula.git",
-            "git@github.com:test_organisation/test2-formula.git",
-            "git@github.com:test_organisation/test3-formula.git"
-        ],
-        "entry": ["dummy"]
-    }
-
-    # Sample config that yaml load will fail to parse
-    _sample_metadata_bad_yaml = {
-        "dependencies": [
-            "git@github.com:test_organisation/test1-formula.git",
-            "git@github.com:test_organisation/test1-formula.git",
-            "git@github.com:test_organisation/test2-formula.git",
-            "git@github.com:test_organisation/test3-formula.git",
-            "git@github.com:test_organisation/test3-formula.git"
+            "git@github.com:test_organisation/test1-formula.git==v1.0.1",
+            "git@github.com:test_organisation/test2-formula.git==v2.0.1",
+            "git@github.com:test_organisation/test3-formula.git==v3.0.1"
         ],
         "entry": ["dummy"]
     }
@@ -63,11 +51,17 @@ class TestMetadataHandling(unittest.TestCase):
                             "test_resolve_metadata_duplicates: Entry '%s' not found in de-duplicated metadata"
                             % (expected_metadata_entry))
 
+    @raises(TypeError)
     def test_resolve_metadata_duplicates_bad_metadata_object(self):
         """
-        Check if resolve_metadata_duplicates can handle bad yaml
-        data without breaking anything
+        Check if bad yaml metadata will throw up a TypeError.
         """
-        expected = self._sample_metadata_bad_yaml
-        result = helpers.resolve_metadata_duplicates(self._sample_metadata_bad_yaml)
-        self.assertEqual(result, expected, "")
+        # Callable with bad metadata
+        helpers.resolve_metadata_duplicates("not-a-dictionary")
+
+    @raises(IndexError)
+    def test_resolve_metadata_duplicates_metadata_missing_index(self):
+        """
+        Check if metadata with a missing index will throw an error
+        """
+        helpers.resolve_metadata_duplicates({})

--- a/tests/test_metadata_handling.py
+++ b/tests/test_metadata_handling.py
@@ -1,0 +1,80 @@
+import unittest
+import yaml
+from shaker import helpers
+
+class TestMetadataHandling(unittest.TestCase):
+    
+    # Sample metadata with duplicates
+    _sample_metadata_duplicates = \
+"""
+dependencies:
+    - git@github.com:test_organisation/test1-formula.git
+    - git@github.com:test_organisation/test1-formula.git
+    - git@github.com:test_organisation/test2-formula.git
+    - git@github.com:test_organisation/test3-formula.git
+    - git@github.com:test_organisation/test3-formula.git
+entry:
+    - dummy
+"""
+    _sample_metadata_no_duplicates = \
+"""
+dependencies:
+    - git@github.com:test_organisation/test1-formula.git
+    - git@github.com:test_organisation/test2-formula.git
+    - git@github.com:test_organisation/test3-formula.git
+entry:
+    - dummy
+"""
+    # Sample config that yaml load will fail to parse
+    _sample_metadata_bad_yaml = \
+    """
+    dependencies--
+        - git@github.com:test_organisation/test1-formula.git
+        - git@github.com:test_organisation/test1-formula.git
+        - git@github.com:test_organisation/test2-formula.git
+        - git@github.com:test_organisation/test3-formula.git
+        - git@github.com:test_organisation/test3-formula.git
+    entry--
+        - dummy
+    """
+    @classmethod
+    def setup_class(cls):
+        pass
+    
+    @classmethod
+    def teardown_class(cls):
+        pass
+    
+    def test_resolve_metadata_duplicates(self):
+        """
+        Check if we successfully remove duplicates from a sample metadata
+        """
+        original_metadata = yaml.load(self._sample_metadata_duplicates)
+        expected_metadata = yaml.load(self._sample_metadata_no_duplicates)
+        resolved_metadata = helpers.resolve_metadata_duplicates(original_metadata)
+        
+        expected_metadata_dependencies = expected_metadata["dependencies"]
+        resolved_metadata_dependencies = resolved_metadata["dependencies"]
+        expected_metadata_entries = expected_metadata["entry"]
+        resolved_metadata_entries = resolved_metadata["entry"]
+
+        # Test dependencies found
+        for expected_metadata_dependency in expected_metadata_dependencies:
+            self.assertTrue(expected_metadata_dependency in resolved_metadata_dependencies, 
+                            "test_resolve_metadata_duplicates: dependency '%s' not found in de-duplicated metadata"
+                            % (expected_metadata_dependency))
+        
+        # Test entry found
+        for expected_metadata_entry in expected_metadata_entries:
+            self.assertTrue(expected_metadata_entry in resolved_metadata_entries, 
+                            "test_resolve_metadata_duplicates: Entry '%s' not found in de-duplicated metadata"
+                            % (expected_metadata_entry))
+            
+    def test_resolve_metadata_duplicates_bad_metadata_object(self):
+        """
+        Check if resolve_metadata_duplicates can handle bad yaml
+        data without breaking anything
+        """
+        expected = yaml.load(self._sample_metadata_bad_yaml)
+        result = helpers.resolve_metadata_duplicates(yaml.load(self._sample_metadata_bad_yaml))
+        self.assertEqual(result, expected, "")


### PR DESCRIPTION
Resolves #14 

Added a simple metadata.yml parsing function to remove duplicate
dependency entries. This does nothing spectacular, it just ignores
any formula named the same as one we already have. It does
this simply by name, ignoring differences in organisation or
anything else. Keeping this simple since there is a change in
metadata.yml format possibly upcoming which may make this
redundanct