### PR TITLE
Strip blank lines and comments from requirements file before reading

### DIFF
--- a/shaker/shaker_metadata.py
+++ b/shaker/shaker_metadata.py
@@ -180,7 +180,9 @@ class ShakerMetadata:
             with open(path, 'r') as infile:
                 loaded_dependencies = []
                 for line in infile:
-                    loaded_dependencies.append(line)
+                    stripped_line = line.strip()
+                    if len(stripped_line) > 0 and stripped_line[0] != '#':
+                        loaded_dependencies.append(line)
 
             if len(loaded_dependencies) > 0:
                 self.local_requirements = shaker.libs.metadata.parse_metadata_requirements(loaded_dependencies)

--- a/tests/test_shaker_metadata.py
+++ b/tests/test_shaker_metadata.py
@@ -652,3 +652,32 @@ class TestShakerMetadata(TestCase):
             mock_path_exists.assert_called_once_with('./test')
             mopen.assert_called_once_with('./test', 'r')
             testfixtures.compare(tempobj.local_requirements, self._sample_dependencies)
+
+    @patch('os.path.exists')
+    def test_load_local_requirements__with_blanks(self,
+                                                  mock_path_exists
+                                                  ):
+        """
+        TestShakerMetadata::test_load_local_requirements: Test loading from local dependency file with blanks and comments
+        """
+        # Setup
+        mock_path_exists.return_value = True
+        text_file_data = '\n'.join(["git@github.com:test_organisation/test1-formula.git==v1.0.1",
+                                    "",
+                                    "git@github.com:test_organisation/test2-formula.git==v2.0.1",
+                                    "             ",
+                                    "#DONT_READ_ME",
+                                    "git@github.com:test_organisation/test3-formula.git==v3.0.1"])
+        with patch('__builtin__.open',
+                   mock_open(read_data=()),
+                   create=True) as mopen:
+            mopen.return_value.__iter__.return_value = text_file_data.splitlines()
+
+            shaker.libs.logger.Logger().setLevel(logging.DEBUG)
+            tempobj = ShakerMetadata(autoload=False)
+            input_directory = '.'
+            input_filename = 'test'
+            tempobj.load_local_requirements(input_directory, input_filename)
+            mock_path_exists.assert_called_once_with('./test')
+            mopen.assert_called_once_with('./test', 'r')
+            testfixtures.compare(tempobj.local_requirements, self._sample_dependencies)


### PR DESCRIPTION
Blank lines and comments in requirements file will cause an error as
they will try to be read as real github urls. This change strips out
blank lines and comments before parsing the entries