### PR TITLE
Properly set vendor roots to the formulas subdirectory

### DIFF
--- a/tests/test_shaker_remote.py
+++ b/tests/test_shaker_remote.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from mock import patch
 from shaker.shaker_remote import ShakerRemote
+from nose.tools import raises
 
 
 class TestShakerRemote(TestCase):
@@ -132,3 +133,131 @@ class TestShakerRemote(TestCase):
         mock_get_repository_sha.side_effect = ["fake_sha",
                                                None]
         mock_install_source.return_value = True
+
+    @patch('shaker.shaker_remote.ShakerRemote._link_dynamic_modules')
+    @patch('os.symlink')
+    @patch('os.path.exists')
+    def test__update_root_links__formula_subdir_exists(self,
+                                                       mock_path_exists,
+                                                       mock_symlink,
+                                                       mock_link_dynamic_modules):
+        """
+        Test root links are made when our formula has docker-formula/docker structure
+        """
+        # Setup
+        sample_dependencies = {
+            'test_organisation/test1-formula': {
+                'source': 'git@github.com:test_organisation/test1-formula.git',
+                'constraint': '==v1.0.1',
+                'organisation': 'test_organisation',
+                'name': 'test1-formula'
+            },
+        }
+        testobj = ShakerRemote(sample_dependencies)
+        # Set path exists check values
+        # True: formula-repos/docker-formula/docker exists
+        # False: _root/docker exists
+        mock_path_exists.side_effect = [
+            True,
+            False
+        ]
+        testobj._update_root_links()
+        source = "vendor/formula-repos/test1-formula/test1"
+        target = "vendor/_root/test1"
+        mock_symlink.assert_called_once_with(source, target)
+        mock_link_dynamic_modules.assert_called_once_with("test1-formula")
+
+    @patch('shaker.shaker_remote.ShakerRemote._link_dynamic_modules')
+    @patch('os.symlink')
+    @patch('os.path.exists')
+    def test__update_root_links__formula_subdir_not_exist(self,
+                                                          mock_path_exists,
+                                                          mock_symlink,
+                                                          mock_link_dynamic_modules):
+        """
+        Test root links are made when our formula has no subdir docker/ structure
+        """
+        # Setup
+        sample_dependencies = {
+            'test_organisation/test1': {
+                'source': 'git@github.com:test_organisation/test1.git',
+                'constraint': '==v1.0.1',
+                'organisation': 'test_organisation',
+                'name': 'test1'
+            },
+        }
+        testobj = ShakerRemote(sample_dependencies)
+        # Set path exists check values
+        # False: formula-repos/docker-formula/docker exists
+        # True: formula-repos/docker/ exists
+        # False: _root/docker exists
+        mock_path_exists.side_effect = [
+            False,
+            True,
+            False
+        ]
+        testobj._update_root_links()
+        source = "vendor/formula-repos/test1"
+        target = "vendor/_root/test1"
+        mock_symlink.assert_called_once_with(source, target)
+        mock_link_dynamic_modules.assert_called_once_with("test1")
+
+    @raises(IOError)
+    @patch('shaker.shaker_remote.ShakerRemote._link_dynamic_modules')
+    @patch('os.symlink')
+    @patch('os.path.exists')
+    def test__update_root_links__formula_link_exists(self,
+                                                     mock_path_exists,
+                                                     mock_symlink,
+                                                     mock_link_dynamic_modules):
+        """
+        Test root links are made when our formula has no subdir docker-formula/ structure
+        """
+        # Setup
+        sample_dependencies = {
+            'test_organisation/test1-formula': {
+                'source': 'git@github.com:test_organisation/test1-formula.git',
+                'constraint': '==v1.0.1',
+                'organisation': 'test_organisation',
+                'name': 'test1-formula'
+            },
+        }
+        testobj = ShakerRemote(sample_dependencies)
+        # Set path exists check values
+        # True: formula-repos/docker-formula/docker exists
+        # True: _root/docker exists
+        mock_path_exists.side_effect = [
+            True,
+            True
+        ]
+        testobj._update_root_links()
+
+    @raises(IOError)
+    @patch('os.path.exists')
+    def test__update_root_links__formula_dirs_not_exist(self,
+                                                        mock_path_exists):
+        """
+        Test we have an exception when we can't find a any directory
+        """
+        # Setup
+        sample_dependencies = {
+            'test_organisation/test1-formula': {
+                'source': 'git@github.com:test_organisation/test1-formula.git',
+                'constraint': '==v1.0.1',
+                'organisation': 'test_organisation',
+                'name': 'test1-formula'
+            },
+        }
+        testobj = ShakerRemote(sample_dependencies)
+        # Set path exists check values
+        # True: formula-repos/docker-formula/docker exists
+        # False: _root/docker exists
+        mock_path_exists.side_effect = [
+            False,
+            False
+        ]
+        testobj._update_root_links()
+        source = "vendor/formula-repos/test1-formula/test1"
+        target = "vendor/_root/test1"
+        mock_symlink.assert_called_with(source, target)
+        mock_link_dynamic_modules.assert_called_with()


### PR DESCRIPTION
The git repos of formulas contain subdirectories with the actual
salt formulas we want to use. For example, if we have a formula
named 'docker-formula', then the actual formula code resides in
'docker-formula/docker'. Maintaining version back-compatibility
we want to link this subdirectory directly in 'roots' so that it
is exposed as 'vendor/root/docker'

- Changes ShakerRemote._update_root_links to use the
  subdirectory 'app-formula/app' for root linking