### PR TITLE
Fix installing source when sha1 ref is a git Tag object

### DIFF
--- a/shaker/libs/github.py
+++ b/shaker/libs/github.py
@@ -804,7 +804,13 @@ def install_source(target_source,
         # Look for tag, if not then look for branch
         try:
             parsed_tag = target_repository.revparse_single(target_tag)
-            target_sha = parsed_tag.hex
+
+            # If parsed tag refs a tag object, look for the actual commit object
+            if parsed_tag.type == pygit2.GIT_OBJ_TAG:
+                target_sha = parsed_tag.peel(pygit2.GIT_OBJ_COMMIT).hex
+            else:
+                target_sha = parsed_tag.hex
+
             shaker.libs.logger.Logger().debug("github::install_source: Found tag sha '%s' for tag '%s'"
                                               % (target_sha, target_tag))
         except KeyError:


### PR DESCRIPTION
If the tag is annotated it references a Tag object rather than a
commit object. This change will look for Tag objects and extract
the actual commit object referenced so that the tree can be
checked out. (Closes #44)