### PR TITLE
Fix salt root linking to use proper relative paths

### DIFF
--- a/shaker/shaker_remote.py
+++ b/shaker/shaker_remote.py
@@ -239,7 +239,8 @@ class ShakerRemote:
                 if os.path.exists(source):
                     if not os.path.exists(target):
                         subdir_found = True
-                        os.symlink(source, target)
+                        relative_source = os.path.relpath(source, os.path.dirname(target))
+                        os.symlink(relative_source, target)
                         shaker.libs.logger.Logger().debug("ShakerRemote::_update_root_links: "
                                                           " Linking %s to %s"
                                                           % (source, target))


### PR DESCRIPTION
The linking of downloaded formulas to the salt root directory is
broken due to bad linking paths. This makes the relative directory
paths correct. (Closes #46)