### PR TITLE
Fix bad indentation on root linking

### DIFF
--- a/shaker/shaker_remote.py
+++ b/shaker/shaker_remote.py
@@ -252,14 +252,14 @@ class ShakerRemote:
 
                     break
 
-        # If we haven't linked a root yet issue an exception
-        if not subdir_found:
-            msg = ("ShakerRemote::_update_root_links: "
-                   "Could not find target link for formula '%s'"
-                   % (name))
-            raise IOError(msg)
-        else:
-            self._link_dynamic_modules(name)
+            # If we haven't linked a root yet issue an exception
+            if not subdir_found:
+                msg = ("ShakerRemote::_update_root_links: "
+                       "Could not find target link for formula '%s'"
+                       % (name))
+                raise IOError(msg)
+            else:
+                self._link_dynamic_modules(name)
 
     def _link_dynamic_modules(self, dependency_name):
         shaker.libs.logger.Logger().debug("ShakerRemote::_link_dynamic_modules(%s) "

--- a/tests/test_shaker_remote.py
+++ b/tests/test_shaker_remote.py
@@ -162,9 +162,9 @@ class TestShakerRemote(TestCase):
             False
         ]
         testobj._update_root_links()
-        source = "vendor/formula-repos/test1-formula/test1"
+        relative_source = "../formula-repos/test1-formula/test1"
         target = "vendor/_root/test1"
-        mock_symlink.assert_called_once_with(source, target)
+        mock_symlink.assert_called_once_with(relative_source, target)
         mock_link_dynamic_modules.assert_called_once_with("test1-formula")
 
     @patch('shaker.shaker_remote.ShakerRemote._link_dynamic_modules')
@@ -197,9 +197,9 @@ class TestShakerRemote(TestCase):
             False
         ]
         testobj._update_root_links()
-        source = "vendor/formula-repos/test1"
+        relative_source = "../formula-repos/test1"
         target = "vendor/_root/test1"
-        mock_symlink.assert_called_once_with(source, target)
+        mock_symlink.assert_called_once_with(relative_source, target)
         mock_link_dynamic_modules.assert_called_once_with("test1")
 
     @raises(IOError)


### PR DESCRIPTION
Running install causes unbound var error due to bad
indentation on the subdir_found check. This fixes the indentation
(Closes #48)

- Update unit tests to deal with relative symlinking