### PR TITLE
Check pygit2 support and handle errors

### DIFF
--- a/shaker/libs/github.py
+++ b/shaker/libs/github.py
@@ -11,6 +11,8 @@ import metadata
 from errors import ConstraintResolutionException
 from errors import GithubRepositoryConnectionException
 import shaker.libs.logger
+from shaker.libs.pygit2_utils import pygit2_parse_error
+
 
 const_re = re.compile('([=><]+)\s*(.*)')
 tag_re = re.compile('v[0-9]+\.[0-9]+\.[0-9]+')
@@ -729,7 +731,10 @@ def open_repository(url,
     git_url = urlparse.urlparse(url)
     username = git_url.netloc.split('@')[0]\
         if '@' in git_url.netloc else 'git'
-    credentials = pygit2.credentials.KeypairFromAgent(username)
+    try:
+        credentials = pygit2.credentials.KeypairFromAgent(username)
+    except AttributeError as e:
+        pygit2_parse_error(e)
 
     # If local directory exists, then make a connection to it
     # Otherwise, clone the remote repo into the new directory

--- a/shaker/libs/pygit2_utils.py
+++ b/shaker/libs/pygit2_utils.py
@@ -1,0 +1,102 @@
+import shaker.libs.logger
+import pygit2
+
+
+class Pygit2SSHUnsupportedError(Exception):
+    pass
+
+
+class Pygit2KepairFromAgentUnsupportedError(Exception):
+    pass
+
+link_installation = "http://www.pygit2.org/install.html"
+error_message_ssh_support = ("shaker.libs.util:check_pygit2: No SSH support found in libgit2. "
+                             "Please install a version with ssh enabled (%s).\n"
+                             "Note, MacOS users using brew should check the output of 'brew info libgit2' "
+                             "for ssh support" % (link_installation))
+
+error_message_credentials_support = ("shaker.libs.util:check_pygit2: Module 'KeypairFromAgent' "
+                                     "not found in pygit2.features. "
+                                     "Please check your pygit installation (%s)."
+                                     % (link_installation))
+
+
+def pygit2_parse_error(e):
+    """
+    Parse a pygit2 specific error into a more understandable context. Will
+    also run some checks to try and help with the problem.
+
+    Args:
+        e(Exception): The exception that was raised
+    """
+    # Common errors to look for are,
+    # AttributeError: 'module' object has no attribute 'KeypairFromAgent'
+    # _pygit2.GitError: Unsupported URL protocol
+    if (isinstance(e, pygit2.GitError) and e.message == "Unsupported URL protocol"):
+        raise Pygit2SSHUnsupportedError(Pygit2SSHUnsupportedError)
+    elif (isinstance(e, AttributeError) and e.message == "'module' object has no attribute 'KeypairFromAgent'"):
+        raise Pygit2KepairFromAgentUnsupportedError(error_message_credentials_support)
+    else:
+        # Re-throw the error with the original trace reserved.
+        raise
+
+
+def pygit2_info():
+    """
+    Output key pygit2/libgit2 information
+    """
+    link_versions = "http://www.pygit2.org/install.html#version-numbers"
+    message_versions = ("shaker.libs.util:check_pygit2: pygit2 *requires* the correct "
+                        "version of libgit2, this version was built against libgit2 version '%s'. "
+                        "Please check the versions on your system if you experience "
+                        "problems. (For compatibility, please refer to %s)"
+                        % (pygit2.LIBGIT2_VERSION, link_versions))
+    shaker.libs.logger.Logger().warning(message_versions)
+
+
+def pygit2_check():
+    """
+    Run all checks for pygit2 sanity and raise exceptions if checks fail
+
+    Raises:
+        Pygit2SSHUnsupportedError: On ssh support check failed
+        Pygit2KepairFromAgentUnsupportedError: On credential support check failed
+    """
+    if not pygit2_check_ssh():
+        raise Pygit2SSHUnsupportedError(error_message_credentials_support)
+    elif not pygit2_check_credentials():
+        raise Pygit2KepairFromAgentUnsupportedError(error_message_credentials_support)
+
+
+def pygit2_check_ssh():
+    """
+    Check for common pygit2 ssh problems
+
+    Return:
+        bool: True if no problems found, False otherwise
+    """
+    # Check for ssh support in libgit2
+    if not (pygit2.features & pygit2.GIT_FEATURE_SSH):
+        shaker.libs.logger.Logger().critical(error_message_ssh_support)
+        return False
+    message_ok = ("shaker.libs.util:pygit2_check_ssh: No ssh problems found. ")
+    shaker.libs.logger.Logger().debug(message_ok)
+    return True
+
+
+def pygit2_check_credentials():
+    """
+    Check for common pygit2 credentials problems
+
+    Return:
+        bool: True if no problems found, False otherwise
+    """
+    link_installation = "http://www.pygit2.org/install.html"
+    # Check for KeypairFromAgent support in pygit2
+    if "KeypairFromAgent" not in vars(pygit2.credentials):
+        shaker.libs.logger.Logger().critical(error_message_credentials_support)
+        return False
+
+    message_ok = ("shaker.libs.util:pygit2_check_credentials: No credential problems found. ")
+    shaker.libs.logger.Logger().debug(message_ok)
+    return True

--- a/shaker/salt_shaker.py
+++ b/shaker/salt_shaker.py
@@ -1,9 +1,11 @@
 import logging
 import os
+import sys
 import warnings
 
 from shaker.libs import logger
 from shaker.libs import metadata
+from shaker.libs import pygit2_utils
 from shaker_metadata import ShakerMetadata
 from shaker_remote import ShakerRemote
 from shaker.libs.errors import ShakerRequirementsUpdateException
@@ -63,6 +65,8 @@ class Shaker(object):
             clone_path(string): The directory to put formula into
             salt_root(string): The directory to link formula into
         """
+        # Run sanity checks on pygit2
+        pygit2_utils.pygit2_check()
 
         self.roots_dir = os.path.join(root_dir, salt_root_path, salt_root)
         self.repos_dir = os.path.join(root_dir, salt_root_path, clone_path)
@@ -272,6 +276,7 @@ def shaker(root_dir='.',
                                              enable_remote_check=enable_remote_check)
     else:
         shaker_instance.update_requirements(simulate=simulate)
+
 
 def get_deps(root_dir, root_formula=None, constraint=None, force=False):
     """

--- a/tests/libs/test_pygit2_utils.py
+++ b/tests/libs/test_pygit2_utils.py
@@ -1,0 +1,116 @@
+import sys
+import traceback
+
+from unittest import TestCase
+from shaker.libs import pygit2_utils
+from mock import patch
+from nose.tools import raises
+
+import pygit2
+
+
+class TestPygit2Utils(TestCase):
+
+    @raises(pygit2_utils.Pygit2KepairFromAgentUnsupportedError)
+    def test_pygit2_parse_error__attributeerror(self):
+        """
+        Test pygit2_parse_error raises correct exception on attribute error
+        """
+        e = AttributeError("'module' object has no attribute 'KeypairFromAgent'")
+        pygit2_utils.pygit2_parse_error(e)
+
+    @raises(pygit2_utils.Pygit2SSHUnsupportedError)
+    def test_pygit2_parse_error__credentialserror(self):
+        """
+        Test pygit2_parse_error raises correct exception on credentials error
+        """
+        e = pygit2.GitError("Unsupported URL protocol")
+        pygit2_utils.pygit2_parse_error(e)
+
+    def test_pygit2_parse_error__preserves_backtrace(self):
+
+        def sub_func():
+            x = {}
+            x.i_should_throw()
+
+        try:
+            try:
+                sub_func()
+            except AttributeError as e:
+                pygit2_utils.pygit2_parse_error(e)
+
+            self.fail("Should have thrown an exception")
+        except:
+            tb = traceback.extract_tb(sys.exc_info()[2])
+            filename,lineno,method,code = tb[-1]
+            self.assertEqual(method, "sub_func")
+            self.assertEqual(code, "x.i_should_throw()")
+
+    @patch("pygit2.credentials", spec={})
+    def test_pygit2_check_credentials__no_keychain(self, mock_pygit2_credentials):
+        """
+        TestPygit2Utils:test_pygit2_check_credentials_no_keychain: Check for missing credentials support
+        """
+        mock_pygit2_credentials.return_value = None
+        result = pygit2_utils.pygit2_check_credentials()
+        self.assertFalse(result)
+
+    @raises(pygit2_utils.Pygit2SSHUnsupportedError)
+    @patch("shaker.libs.pygit2_utils.pygit2_check_ssh")
+    def test_pygit2_check__no_ssh(self,
+                                  mock_check_ssh):
+        """
+        Test pygit_check raises exception when ssh check fails
+        """
+        mock_check_ssh.return_value = False
+        pygit2_utils.pygit2_check()
+
+    @raises(pygit2_utils.Pygit2KepairFromAgentUnsupportedError)
+    @patch("shaker.libs.pygit2_utils.pygit2_check_credentials")
+    @patch("shaker.libs.pygit2_utils.pygit2_check_ssh")
+    def test_pygit2_check__no_credentials(self,
+                                          mock_check_ssh,
+                                          mock_check_credentials):
+        """
+        Test pygit_check raises exception when credential check fails
+        """
+        mock_check_ssh.return_value = True
+        mock_check_credentials.return_value = False
+        pygit2_utils.pygit2_check()
+
+    @patch("shaker.libs.pygit2_utils.pygit2")
+    def test_pygit2_check_ssh__have_ssh(self,
+                                        mock_pygit2):
+        """
+        TestPygit2Utils:test_pygit2_check_ssh: Check for successful ssh support
+        """
+        # Mock needed pygit2 components
+        mock_pygit2.features = pygit2.GIT_FEATURE_SSH
+        mock_pygit2.GIT_FEATURE_SSH = pygit2.GIT_FEATURE_SSH
+        mock_pygit2.GIT_FEATURE_HTTPS = pygit2.GIT_FEATURE_HTTPS
+
+        result = pygit2_utils.pygit2_check_ssh()
+        self.assertTrue(result)
+
+    @patch("shaker.libs.pygit2_utils.pygit2")
+    def test_pygit2_check_ssh__no_ssh(self,
+                                      mock_pygit2):
+        """
+        TestPygit2Utils:test_pygit2_check_no_ssh: Check for missing ssh support
+        """
+        # Mock needed pygit2 components
+        mock_pygit2.features = pygit2.GIT_FEATURE_HTTPS
+        mock_pygit2.GIT_FEATURE_SSH = pygit2.GIT_FEATURE_SSH
+        mock_pygit2.GIT_FEATURE_HTTPS = pygit2.GIT_FEATURE_HTTPS
+
+        result = pygit2_utils.pygit2_check_ssh()
+        self.assertFalse(result)
+
+    @patch("pygit2.credentials", spec={})
+    def test_pygit2_check_credentials__have_keychain(self, mock_pygit2_credentials):
+        """
+        TestPygit2Utils:test_pygit2_check_credentials_keychain: Check for successful credentials support
+        """
+        mock_pygit2_credentials.KeypairFromAgent = ""
+        result = pygit2_utils.pygit2_check_credentials()
+        self.assertTrue(result)


### PR DESCRIPTION
Pygit2 errors are obtuse and difficult to debug. This change will
try to make the problems easier to interpret and provide some
checks for known common issues.

* Added pygit2_util lib to handle checking for common problems
* Added calling pygit2 checks when initialising salt shaker
* Try/except when calling pygit2.credentials in github, then let
pygit2_util handle the error if it arises
* Added tests for ssh and KeypairFromAgent checks to pygit2_utils.

(Closes ministryofjustice/salt-shaker#22)