### PR TITLE
Check for ssh agent keys

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pygit2 >= 0.21.4
 PyYAML
 requests[security]
+paramiko
 parse
 


### PR DESCRIPTION
If we dont have our github keys added to the ssh agent, salt-shaker
will fail when trying to checkout repositories. This change
runs a simple check on the available ssh agent ids.