### PR TITLE
Fix versioning on gihub releases

### DIFF
--- a/shaker/libs/github.py
+++ b/shaker/libs/github.py
@@ -6,7 +6,7 @@ import sys
 import pygit2
 from parse import parse
 import urlparse
-
+from distutils.version import LooseVersion
 import metadata
 from errors import ConstraintResolutionException
 from errors import GithubRepositoryConnectionException
@@ -333,7 +333,7 @@ def get_latest_tag(tag_versions,
     shaker.libs.logger.Logger().debug("github::get_latest_tag: "
                                       "Latest from %s"
                                       % (tag_versions))
-    tag_versions.sort()
+    tag_versions.sort(key=LooseVersion)
     for tag_version in reversed(tag_versions):
         is_release = is_tag_release("v%s" % tag_version)
         is_prerelease = is_tag_prerelease("v%s" % tag_version)


### PR DESCRIPTION
This change fixes sorting to use knowledge about semver to order
versions correctly. Currently 0.9 > 0.10 since it sorted simply.
Now 0.10 > 0.9 as the algorithm knows about semver. Using loose
versioning also means that it can handle pre-release tages such
as .rc1 etc